### PR TITLE
add a context for referencing fields, and tracking usage

### DIFF
--- a/sites-config/features.json
+++ b/sites-config/features.json
@@ -26,6 +26,7 @@
         "id",
         "uid",
         "meta",
+        "logo",
         "name",
         "address",
         "mainPhone",

--- a/src/ProfileContext.tsx
+++ b/src/ProfileContext.tsx
@@ -1,0 +1,37 @@
+import React, { RefObject, useContext, useEffect } from "react";
+import { Profile, FieldReference, isFieldReference, ValueOrFieldReference, KeysWithValsOfType } from "./types";
+
+/**
+ * A helper to create a Context and Provider with no upfront default value, and
+ * without having to check for undefined all the time.
+ */
+ function createCtx<A extends {} | null>() {
+  const ctx = React.createContext<A | undefined>(undefined);
+  function useCtx() {
+    const c = useContext(ctx);
+    if (c === undefined)
+      throw new Error("useCtx must be inside a Provider with a value");
+    return c;
+  }
+  return [useCtx, ctx.Provider] as const; // 'as const' makes TypeScript infer a tuple
+}
+
+// We still have to specify a type, but no default
+export const [useProfile, ProfileProvider] = createCtx<Profile>();
+
+function useField<T>(field: FieldReference<T>, ref: RefObject<HTMLElement>) {
+	const context = useProfile();
+	useEffect(() => {
+		if (ref.current) ref.current.setAttribute("data-data-track", field.name)
+	})
+	return context[field.name]
+}
+
+export function useResolvedValue<T>(x: ValueOrFieldReference<T>, ref: RefObject<HTMLElement>) {
+	if (isFieldReference<T>(x)) return useField<T>(x, ref)
+  return x;
+}
+
+export { useField } ;
+
+export default ProfileProvider;

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { useResolvedValue } from "../ProfileContext";
+import { ValueOrFieldReference } from "../types"
+
+interface AboutProps {
+	name: ValueOrFieldReference<string>
+}
+
+export default function About(props: AboutProps) {
+	const ref = React.createRef<HTMLSpanElement>();
+	const name = useResolvedValue(props.name, ref); // type safe!
+	return (
+		<div>
+			Learn More About <span ref={ref}>{name}</span>!
+		</div>
+	)
+}

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -1,10 +1,4 @@
-export type Address = {
-  line1: string;
-  city: string;
-  region: string;
-  postalCode: string;
-  countryCode: string;
-};
+import { Address } from "../types";
 
 type Banner = {
   name?: string;

--- a/src/components/static-map.tsx
+++ b/src/components/static-map.tsx
@@ -1,7 +1,4 @@
-type Coordinates = {
-  latitude: string;
-  longitude: string;
-};
+import { Coordinates } from "../types";
 
 const StaticMap = (props: Coordinates) => {
   const { latitude, longitude } = props;

--- a/src/index.css
+++ b/src/index.css
@@ -17,3 +17,19 @@
 .secondary-cta{
     @apply bg-sky-700 hover:bg-sky-800;
 }
+
+[data-data-track] {
+    border: 1px solid red;
+    position: relative;
+}
+
+[data-data-track]:hover::before {
+    content: attr(data-data-track);
+    position: absolute;
+    background: rgba(0, 0, 0, 0.7);
+    border-radius: 7px;
+    padding: 3px;
+    color: white;
+    top: -30px;
+    left: 0;
+}

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -1,3 +1,4 @@
+import { FieldReference } from '../types';
 import Banner from '../components/banner';
 import Header from '../components/header';
 import Footer from '../components/footer';
@@ -10,6 +11,9 @@ import PhotoGallery from '../components/photo-gallery';
 import { reactWrapper } from '../wrapper';
 import { renderToString } from 'react-dom/server';
 import '../index.css';
+import About from '../components/About';
+import { Profile } from '../types';
+import ProfileProvider from '../ProfileContext';
 
 export const config = {
   name: 'index',
@@ -28,6 +32,7 @@ export const config = {
       'mainPhone',
       'description',
       'hours',
+      'logo',
       'photoGallery',
       'slug',
       'geocodedCoordinate',
@@ -53,43 +58,47 @@ export const getPath = (data: any) => {
 
 const Index = ({ data }: { data: any }) => {
   const { document } = data;
-  const { streamOutput } = document;
+  const { streamOutput }: { streamOutput: Profile } = document;
   const { name, address, openTime, hours, mainPhone, _site, geocodedCoordinate, services, photoGallery } = streamOutput;
 
   return (
     <>
-      <div className="centered-container">
-        <Header
-          logo="https://cdn.fs.brandfolder.com/cache=expiry:604800/deY3VGFpSjC761Abjbfc"
-          links={_site.c_header}
-        ></Header>
-      </div>
-      <Banner name={name} address={address} openTime={openTime}>
-        <div className="bg-white h-40 w-1/5 flex items-center justify-center text-center flex-col space-y-4 rounded-lg">
-          <div className="text-black text-base">Visit Us Today!</div>
-          <Cta buttonText="Get Directions" url="http://google.com" style="primary-cta" />
+      <ProfileProvider value={streamOutput}>
+        <div className="centered-container">
+          <Header
+            logo="https://cdn.fs.brandfolder.com/cache=expiry:604800/deY3VGFpSjC761Abjbfc"
+            links={_site.c_header}
+          ></Header>
         </div>
-      </Banner>
-      <div className="centered-container">
-        <div className="section">
-          <div className="grid grid-cols-3 gap-x-10 gap-y-10">
-            <div className="bg-gray-100 p-5 space-y-12">
-              <Contact address={address} phone={mainPhone}></Contact>
-              <List list={services}></List>
-            </div>
-            <div className="col-span-2 pt-5 space-y-10">
-              <div>{hours && <Hours title={'Restaurant Hours'} hours={hours} />}</div>
-              <StaticMap latitude={geocodedCoordinate.latitude} longitude={geocodedCoordinate.longitude}></StaticMap>
+        <Banner name={name} address={address} openTime={openTime}>
+          <div className="bg-white h-40 w-1/5 flex items-center justify-center text-center flex-col space-y-4 rounded-lg">
+            <div className="text-black text-base">Visit Us Today!</div>
+            <Cta buttonText="Get Directions" url="http://google.com" style="primary-cta" />
+          </div>
+        </Banner>
+        <About name="Hardcoded Location Name" />
+        <About name={FieldReference("name")} /> {/* Type safe, won't let you use "address" for example */}
+        <div className="centered-container">
+          <div className="section">
+            <div className="grid grid-cols-3 gap-x-10 gap-y-10">
+              <div className="bg-gray-100 p-5 space-y-12">
+                <Contact address={address} phone={mainPhone}></Contact>
+                <List list={services}></List>
+              </div>
+              <div className="col-span-2 pt-5 space-y-10">
+                <div>{hours && <Hours title={'Restaurant Hours'} hours={hours} />}</div>
+                <StaticMap latitude={geocodedCoordinate.latitude} longitude={geocodedCoordinate.longitude}></StaticMap>
+              </div>
             </div>
           </div>
+          {/* <div className="section">
+            <PhotoGallery photoGallery={photoGallery}></PhotoGallery>
+          </div> */}
+          {/* <div className="section">
+          </div> */}
+          <Footer></Footer>
         </div>
-        {/* <div className="section">
-          <PhotoGallery photoGallery={photoGallery}></PhotoGallery>
-        </div> */}
-        {/* <div className="section">
-        </div> */}
-        <Footer></Footer>
-      </div>
+      </ProfileProvider>
     </>
   );
 };

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,0 +1,89 @@
+export interface FieldReference<T> {
+  name: KeysWithValsOfType<Profile, T>
+  "__fieldRefMarker": never // there's a way to do this with symbols I just don't know it
+}
+
+export type ValueOrFieldReference<T> = T | FieldReference<T>
+
+export type KeysWithValsOfType<T,V> = keyof { [ P in keyof T as T[P] extends V ? P : never ] : P };
+
+export function FieldReference<T>(x: KeysWithValsOfType<Profile, T>): FieldReference<T> {
+  return {name: x, "__fieldRefMarker": null} as FieldReference<T>
+}
+
+export function isFieldReference<T>(x: any | FieldReference<T>): x is FieldReference<T> {
+  if (typeof x !== "object") return false;
+  return "__fieldRefMarker" in x
+}
+
+export type Address = {
+  line1: string;
+  line2?: string;
+  city: string;
+  region: string;
+  postalCode: string;
+  countryCode: string;
+};
+
+export type Coordinates = {
+  latitude: number;
+  longitude: number;
+};
+
+export interface Hours extends Record<string, any> {
+  monday?: Day;
+  tuesday?: Day;
+  wednesday?: Day;
+  thursday?: Day;
+  friday?: Day;
+  saturday?: Day;
+  sunday?: Day;
+}
+
+export type Day = {
+  isClosed: boolean;
+  openIntervals: OpenIntervals[];
+};
+
+export type OpenIntervals = {
+  start: string;
+  end: string;
+};
+
+export type Thumbnail = {
+  height: number;
+  width: number;
+  url: string;
+};
+
+type Photo = {
+  description: string
+  details: string
+  image: Image;
+};
+
+type Image = {
+  height?: number;
+  width?: number;
+	alternateText?: string
+  url: string;
+  thumbnails?: Thumbnail[];
+};
+
+export type PhotoGallery = {
+  photoGallery: Image[];
+};
+
+// Should autogenerate this from stream schema or something
+export interface Profile {
+	name: string
+	logo: Photo
+	address: Address
+	openTime: string
+	hours: Hours
+	mainPhone: string
+	geocodedCoordinate: Coordinates
+	services: string[]
+	photoGallery: PhotoGallery
+	_site: any
+}


### PR DESCRIPTION
One of the things TEMs have asked for for a long time is a way to figure out which fields are being used on a page and where. 

The easiest way to enable that would be to have developers manually tag elements with a `data-yext-field={fieldName}` attribute. This is an attempt at something that's:
* less effort on the developer
* not possible for the tracking annotations and actual field usage to get out of sync
* type safe

things I don't like: 
* it's annoying you have to make a ref. we could make `useResolvedValue` just take the field name and return a ref, but then it's awkward if you want to use multiple fields and re-use the same ref. maybe the second param is optional? 

Another option could be to have a class for each field type like:
```
class SingleLineText() {
  constructor(fieldName) { this.name = fieldName; this.value = profile[fieldName] };
  render() {
    return debugModeEnabled ? <span data-yext-field={this.name}>{this.value}</span> : {this.value}
  }
```
I like that this way doesn't require implementing those classes, and that it doesn't affect rendering. We can make an `Address` component for example without needing to tie it explicitly to the Address profile type.  

It also means it tracks when fields are used for logic but not rendered (switching on an option field for example). If we wanted we could make a `useLogicalField` or something that would visually differentiate between the two types of usages.

Screenshot (the name appears on hover):
<img width="840" alt="image" src="https://user-images.githubusercontent.com/6308571/164587607-31eb29cc-07f6-4d96-bc95-e264f09dec3c.png">
