### PR TITLE
WIP: add Custom Field debugger

### DIFF
--- a/customFieldDebugger.js
+++ b/customFieldDebugger.js
@@ -1,0 +1,360 @@
+function makeid(length) {
+  var result           = '';
+  var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  var charactersLength = characters.length;
+  for ( var i = 0; i < length; i++ ) {
+    result += characters.charAt(Math.floor(Math.random() * 
+charactersLength));
+  }
+  return result;
+}
+
+function makeNumber(length) {
+  var result           = '';
+  var characters       = '123456789';
+  var charactersLength = characters.length;
+  for ( var i = 0; i < length; i++ ) {
+    result += characters.charAt(Math.floor(Math.random() * 
+charactersLength));
+  }
+  return Number(result);
+}
+
+function randomizeHours(hours) {
+  return {
+    sunday: {isClosed: false, openIntervals: [{start: '1:01', end: '1:02'}]},
+    monday: {isClosed: false, openIntervals: [{start: '1:03', end: '1:04'}]},
+    tuesday: {isClosed: false, openIntervals: [{start: '1:05', end: '1:06'}]},
+    wednesday: {isClosed: false, openIntervals: [{start: '1:07', end: '1:08'}]},
+    thursday: {isClosed: false, openIntervals: [{start: '1:09', end: '1:10'}]},
+    friday: {isClosed: false, openIntervals: [{start: '1:11', end: '1:12'}]},
+    saturday: {isClosed: false, openIntervals: [{start: '1:13', end: '1:14'}]},
+  };
+}
+
+function randomize(v) {
+  if (typeof v === 'string') return makeid(12);
+  if (typeof v === 'number') return makeNumber(12);
+  if (Array.isArray(v)) return v.map(randomize)
+  if (typeof v === 'object') return Object.keys(v).reduce((out, key) => ({...out, [key]: key === 'hours' ? randomizeHours(v[key]) : randomize(v[key])}), {});
+}
+
+// Returns a flattened object while preserving nested key names
+//  using '.' as a separator ex.
+//  {parent: {child: 'hello'}} => {parent.child: 'hello'}
+function flattenObj(input, parentKey="") {
+  let flattened = {};
+  Object.entries(input).forEach(([key, val]) => {
+    if (typeof val === 'object') {
+      flattened = {
+        ...flattened,
+        ...flattenObj(val, `${parentKey}${key}.`),
+      }
+    } else if (typeof val === 'array') {
+        val.forEach((el, idx) => {
+          flattened = {
+            ...flattened,
+            ...flattenObj(el, `${parentKey}${key}.${idx}.`),
+          }
+        })
+    } else {
+      flattened[`${parentKey}${key}`] = val;
+    }
+  });
+  return flattened;
+}
+
+// Returns a CSS selector using :nth-child to uniquely identify any DOM node
+function getDOMNodeAddress(node, addressIndices = []) {
+  // Exit condition
+  if (node.nodeType === Node.DOCUMENT_NODE) {
+    // Convert the array of indices to a CSS selector first
+    let selector = "html";
+    // element at index 0 is always the `<html>` element, so shift() to ignore it
+    addressIndices.shift();
+    addressIndices.forEach(index => {
+      // TextNodes will have a -1 at the end since a textNode is not considered a child
+      // :nth-child() is 1 indexed instead of 0 indexed
+      if (index != -1) {
+        selector = `${selector} > :nth-child(${index+1})`;
+      }
+    });
+    return selector;
+  }
+
+  // Find the index of this node among it's siblings and recurse
+  const siblingIndex = Array.from(node.parentNode.children).indexOf(node);
+  return getDOMNodeAddress(node.parentNode, [siblingIndex, ...addressIndices]);
+}
+
+// Set up a MutationObserver which will re-run the CFDebugger code if the DOM changes.
+//  This will catch any React re-renders and make sure the newly rendered elements
+//  have the appropriate markup.
+// @param rerender: the React render function for the root React element
+function enableWatchDOMForChanges(rerender) {
+  const observerConfig = { attributes: true, childList: true, subtree: true };
+  const observer = new MutationObserver((mutationsList, observer) => {
+    mutationsList.forEach(mutation => {
+      // Don't infinite loop if detecting attribute mutation & attribute is a CFD-attribute
+      if (mutation.attributeName && mutation.attributeName.includes('cfd')) {
+        return;
+      }
+
+      // No new nodes added, so we don't need to update anything
+      if (mutation.addedNodes.length < 1) {
+        return;
+      }
+      
+      // Temporarily disable the observer to prevent infinite recursion with react re-renders
+      observer.disconnect();
+
+      // Remove any data-attributes or elements added by previous runs of the CFDebugger
+      disableAndCleanupCFDebugger();
+
+      // Re-render the React App with randomized props. This has to be done in the real 
+      //  DOM to accurately track React State changes which have happened since page load.
+      // If we try to clone the DOM & render in virtual DOM, the State is reset to default values.
+      //  This breaks in the case where the State is causing DOM elements to be hidden/shown, like
+      //  for example the FAQ component expand/collapse.
+      const [fakeProps, flatProps] = generateRandomizedProps(window._RSS_PROPS_);
+      rerender(fakeProps); // <- this visibly updates the page (its the only way to preserve the existing State?)
+      const usageList = findFieldValueUsages(flatProps, document.body);
+
+      // Fix the visible page by re-rendering with the real data
+      rerender(window._RSS_PROPS_);
+
+      // And re-enable all of the CFDebugger features
+      addDataAttributeTags(usageList, document.body);
+      enableTooltipVisualization();
+      enableUsageVisualization();
+
+      // Re-enable the observer to watch for any future changes
+      observer.observe(document.querySelector('#root'), observerConfig);
+    });
+  });
+
+  observer.observe(document.querySelector('#root'), observerConfig);
+}
+
+// Remove all created data attributes & DOM Nodes
+function disableAndCleanupCFDebugger() {
+  document.querySelectorAll('[data-cfd-tooltip]').forEach(el => {
+    Object.entries(el.dataset).forEach(([key, _]) => {
+      if (key.includes('cfdSource') || key.includes('cfdUsageType') || key.includes('cfdTooltip')) {
+        delete el.dataset[key];
+      }
+    });
+  });
+
+  document.querySelectorAll('CFD-tooltip').forEach(el => el.remove());
+  document.querySelectorAll('CFD-usagePanel').forEach(el => el.remove());
+}
+
+// Returns Array of two items:
+//  1. `props` with random values for profile fields (in `props.data.document.streamOutput`)
+//  2. Flattened list of profile fields
+function generateRandomizedProps(props) {
+  const randomizedProfile = randomize(props.data.document.streamOutput);
+  const randomizedProps = {
+    document: {streamOutput: randomizedProfile},
+    __meta: { // throws error if this doesn't exist (?)
+      manifest: { bundlerManifest: {}},
+    },
+  }
+
+  return [{data: randomizedProps}, flattenObj(randomizedProfile)];
+}
+
+// Returns a list of `usage` objects which describe where and how a `fieldValue` is used
+function findFieldValueUsages(fieldValues, sourceDOM) {
+  const usageList = [];
+  Object.entries(fieldValues).forEach(([key, fieldValue]) => {
+    // Create a filtered Node Iterator which will find locations in `sourceDOM` where `fieldValue` occurs
+    const nodeIterator = document.createNodeIterator(sourceDOM, NodeFilter.SHOW_ALL, node => {
+      // The fieldValue could be textContent for a node
+      if (node.nodeType === Node.TEXT_NODE && node.textContent.includes(fieldValue)) {
+        node.cfdUsage = 'textContent';
+        return NodeFilter.FILTER_ACCEPT;
+
+      // The fieldValue could be an attribute on a node
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const attrs = node.getAttributeNames();
+        for (const attrName of attrs) {
+          if (node.getAttribute(attrName) === fieldValue) {
+            node.cfdUsage = `attribute_${attrName}`;
+            return NodeFilter.FILTER_ACCEPT;
+          }
+        }
+      }
+
+      // We didn't find the fieldValue in this node
+      return NodeFilter.FILTER_REJECT;
+    });
+
+    // Use the iterator to construct `usageList`
+    let nodeWithData;
+    while (nodeWithData = nodeIterator.nextNode()) {
+      // Build a selector for elements in `sourceDOM` using :nth-child selectors
+      let addressSelector = getDOMNodeAddress(nodeWithData);
+
+      usageList.push({
+        selector: addressSelector,
+        key: key,
+        usageType: nodeWithData.cfdUsage,
+      });
+    }
+  });
+
+  return usageList;
+}
+
+// Using the param `usageList`, modify the `targetDOM` to add data-attributes
+function addDataAttributeTags(usageList, targetDOM) {
+  usageList.forEach(usageInfo => {
+    let el = targetDOM.querySelector(usageInfo.selector);
+    el.dataset.cfdTooltip = true;
+    // We need to add a random suffix here so that if a div uses two different
+    //  fields, there won't be namespace conflicts in the data-attributes
+    const randKey = makeNumber(12);
+    el.dataset[`cfdSource_${randKey}`] = usageInfo.key;
+    el.dataset[`cfdUsageType_${randKey}`] = usageInfo.usageType;
+  });
+}
+
+function initCFDebugger(renderFunction) {
+  // Render the initial state of the page with random props in a Virtual DOM
+  const [fakeProps, flatProps] = generateRandomizedProps(window._RSS_PROPS_);
+  const VDOM = document.cloneNode(true);
+  renderFunction(fakeProps, VDOM.querySelector('#root'));
+
+  // Find and tag any field usages
+  const usageList = findFieldValueUsages(flatProps, VDOM.body);
+  addDataAttributeTags(usageList, document.body);
+
+  // Render the UI
+  enableTooltipVisualization();
+  enableUsageVisualization();
+  
+  // Watch for updates
+  enableWatchDOMForChanges(renderFunction);
+}
+
+function enableTooltipVisualization() {
+  // Some code to render a basic hover tooltip UI element
+  document.querySelectorAll('[data-cfd-tooltip]').forEach(el => {
+    // Parse the data stored in the data-attributes cfdSource and cfdUsageType
+    let cfdInfo = {};
+    Object.entries(el.dataset).forEach(([key, val]) => {
+      if (key.includes('cfdSource')) {
+        const [_, id] = key.split('_');
+        if (!cfdInfo[id]) { cfdInfo[id] = {}; }
+        cfdInfo[id].source = el.dataset[key];
+      } else if (key.includes('cfdUsageType')) {
+        const [_, id] = key.split('_');
+        if (!cfdInfo[id]) { cfdInfo[id] = {}; }
+        cfdInfo[id].usage = el.dataset[key];
+      }
+    });
+
+    // Create & render a new div when the element is hovered
+    const toolTipEl = document.createElement('div');
+    toolTipEl.classList.add('CFD-tooltip');
+    let innerHTML = '';
+    Object.entries(cfdInfo).forEach(([key, val]) => {
+      innerHTML = innerHTML + `<div class="CFD-section"><span class="CFD-source">Data Field: ${val.source}</span><span class="CFD-usage">Usage: ${val.usage}</span></div>`;
+    });
+    toolTipEl.innerHTML = innerHTML;
+
+    el.addEventListener('mouseenter', () => {
+      const elRect = el.getBoundingClientRect();
+      toolTipEl.style.top = `${elRect.bottom + window.scrollY}px`;
+      toolTipEl.style.left = `${elRect.left}px`;
+      document.body.appendChild(toolTipEl);
+    });
+    el.addEventListener('mouseleave', () => {
+      toolTipEl.remove();
+    });
+  });
+}
+
+function enableUsageVisualization() {
+  const flatProfile = flattenObj(window._RSS_PROPS_.data.document.streamOutput);
+
+  const cfEls = document.querySelectorAll('[data-cfd-tooltip]');
+  const usageMap = {};
+
+  Object.entries(flatProfile).forEach(([profileKey, _]) => {
+    // Search the page to see if this custom field is in use by checking the 'data-cfd-source' attribute
+    cfEls.forEach(el => {
+      Object.entries(el.dataset).forEach(([_, tooltipVal]) => {
+        if (profileKey === tooltipVal) {
+          usageMap[profileKey] = [
+            ...(usageMap[profileKey] ? usageMap[profileKey] : []),
+            el
+          ];
+        }
+      });
+    });
+  });
+
+  let usagePanelEl = document.createElement('div');
+  usagePanelEl.classList.add('CFD-usagePanel', 'CFDUsagePanel');
+  let usagePanelScrollableEl = document.createElement('div');
+  usagePanelScrollableEl.classList.add('CFDUsagePanel-scrollable');
+  usagePanelEl.appendChild(usagePanelScrollableEl);
+
+
+  function buildFieldSummaryHTML(key, val) {
+    let shortKey = key;
+    const prefix = 'document.streamOutput.';
+    if (shortKey.startsWith(prefix)) {
+      shortKey = shortKey.slice(prefix.length);
+    }
+
+    let shortVal = val;
+    const maxStrLen = 40;
+    if (typeof shortVal === 'string' && shortVal.length > maxStrLen) {
+      shortVal = `${shortVal.slice(0, maxStrLen)}...`;
+    }
+    return `
+      <span class="CFDUsagePanel-fieldSummary">
+        <span class="CFDUsagePanel-fieldSummaryKey">${shortKey}</span>
+        <span class="CFDUsagePanel-fieldSummaryVal">${shortVal}</span>
+      </span>
+    `;
+  }
+
+  Object.entries(flatProfile).forEach(([key, val]) => {
+    // If the prop is used on the page, it will be in 'usageMap'
+    if (usageMap[key]) {
+      let usageDiv = document.createElement('div');
+      usageDiv.classList.add('CFDUsagePanel-field', 'CFDUsagePanel-field--used');
+      usageDiv.innerHTML = `<span class="CFDUsagePanel-fieldStatus">In Use</span>${buildFieldSummaryHTML(key, val)}`;
+      usageDiv.addEventListener('click', () => {
+        document.querySelectorAll('.CFD-isSelected').forEach(el => el.classList.remove('CFD-isSelected'));
+        usageMap[key][0].classList.add('CFD-isSelected');
+        window.scrollTo({top: usageMap[key][0].scrollTop, behavior: 'smooth'});
+      });
+      usagePanelScrollableEl.appendChild(usageDiv);
+    } else {
+      let usageDiv = document.createElement('div');
+      usageDiv.classList.add('CFDUsagePanel-field', 'CFDUsagePanel-field--notUsed');
+      usageDiv.innerHTML = `<span class="CFDUsagePanel-fieldStatus">Not Used</span>${buildFieldSummaryHTML(key, val)}`;
+      usagePanelScrollableEl.appendChild(usageDiv);
+    }
+  });
+
+  // Add a button to expand/collapse the UsagePanel
+  const btn = document.createElement('button');
+  btn.classList.add('CFD-usageBtn');
+  btn.addEventListener('click', () => {
+    usagePanelEl.classList.toggle('is-visible');
+  });
+  usagePanelEl.appendChild(btn);
+
+  document.body.appendChild(usagePanelEl);
+}
+
+export {
+  initCFDebugger,
+}

--- a/entry.js
+++ b/entry.js
@@ -71,6 +71,13 @@ const hydrate = async () => {
           }),
           container);
         }
+
+        // Set up the profile proxy
+        const proxyProfile = module.getProxyProfile(window._RSS_PROPS_.data.document.streamOutput);
+        // Save a non-proxied version of the props so the CF Debugger doesn't trigger itself
+        window._RSS_PROPS_NOPROXY_ = structuredClone(window._RSS_PROPS_);
+        window._RSS_PROPS_.data.document.streamOutput = proxyProfile;
+
         module.initCFDebugger(rerender);
       });
   }

--- a/entry.js
+++ b/entry.js
@@ -41,7 +41,7 @@ const hydrate = async () => {
    */
   const templateFilename = window._RSS_TEMPLATE_?.split('.')[0];
 
-  const { default: component, render: renderComponent } = (await routes.find((route) => route.name === templateFilename)?.getComponent()) || {};
+  const { default: component } = (await routes.find((route) => route.name === templateFilename)?.getComponent()) || {};
 
   ReactDOM.hydrate(
     _jsx(App, {
@@ -56,169 +56,26 @@ const hydrate = async () => {
     document.getElementById('root'),
   );
 
-  function makeid(length) {
-    var result           = '';
-    var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    var charactersLength = characters.length;
-    for ( var i = 0; i < length; i++ ) {
-      result += characters.charAt(Math.floor(Math.random() * 
-  charactersLength));
-   }
-   return result;
-  }
-  
-  function makeNumber(length) {
-    var result           = '';
-    var characters       = '123456789';
-    var charactersLength = characters.length;
-    for ( var i = 0; i < length; i++ ) {
-      result += characters.charAt(Math.floor(Math.random() * 
-  charactersLength));
-   }
-   return Number(result);
-  }
-
-  function randomize(v) {
-    if (typeof v === 'string') return makeid(12);
-    if (typeof v === 'number') return makeNumber(12);
-    if (Array.isArray(v)) return v.map(randomize)
-    if (typeof v === 'object') return Object.keys(v).reduce((out, key) => ({...out, [key]: key === 'hours' ? v[key] : randomize(v[key])}), {})
-  }
-
-  // Returns a flattened object while preserving nested key names
-  //  using '.' as a separator ex.
-  //  {parent: {child: 'hello'}} => {parent.child: 'hello'}
-  function flattenObj(input, parentKey="") {
-    let flattened = {};
-    Object.entries(input).forEach(([key, val]) => {
-      if (typeof val === 'object') {
-        flattened = {
-          ...flattened,
-          ...flattenObj(val, `${parentKey}${key}.`),
+  window.enableCFDebugger = function() {
+    import ('./customFieldDebugger.js')
+      .then(module => {
+        function rerender(props, container=document.getElementById('root')) {
+          ReactDOM.render(_jsx(App, {
+            page: {
+              props: props,
+              path: window.location.pathname,
+              component: component,
+            },
+            translations: window._RSS_I18N_,
+            locale: window._RSS_LOCALE_,
+          }),
+          container);
         }
-      } else if (typeof val === 'array') {
-         val.forEach((el, idx) => {
-           flattened = {
-             ...flattened,
-             ...flattenObj(el, `${parentKey}${key}.${idx}.`),
-           }
-         })
-      } else {
-        flattened[`${parentKey}${key}`] = val;
-      }
-    });
-    return flattened;
-  }
-
-  // Returns an array of sibling indicies from document root to the param `node`
-  //  so I can use :nth-child selectors to uniquely identify any element
-  function getDOMNodeAddress(node, address = []) {
-    if (node.nodeType === Node.DOCUMENT_NODE) {
-      return address;
-    }
-
-    // Find the index of this node among it's siblings
-    const siblingIndex = Array.from(node.parentNode.children).indexOf(node);
-    return getDOMNodeAddress(node.parentNode, [siblingIndex, ...address]);
-  }
-
-  // re-calculate the HTML string of the component with random props (no update to the visible page)
-  const fakeProps = {
-    document: {streamOutput: randomize(window._RSS_PROPS_.data.document.streamOutput)},
-    __meta: { // throws error if this doesn't exist (?)
-      manifest: { bundlerManifest: {}},
-    },
-  }
-  const randomizedComponentString = renderComponent(fakeProps);
-  const randomizedComponentDOMNode = new DOMParser().parseFromString(randomizedComponentString, 'text/html');
-  const flatProps = flattenObj(fakeProps);
-
-  // For each randomized prop, search the randomized DOM for where the random string occurs
-  Object.entries(flatProps).forEach(([key, val]) => {
-
-    // Create a filtered Node Iterator which will find locations in the DOM where the random string occurs
-    const nodeIterator = document.createNodeIterator(randomizedComponentDOMNode.body, NodeFilter.SHOW_ALL, (node) => {
-      // The string could be textContent for an element
-      if (node.nodeType === Node.TEXT_NODE && node.textContent === val) {
-        node.cfdUsage = 'textContent';
-        return NodeFilter.FILTER_ACCEPT;
-
-      // The string could be an attribute on an element
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        const attrs = node.getAttributeNames();
-        for (const attrName of attrs) {
-          if (node.getAttribute(attrName) === val) {
-            node.cfdUsage = `attribute_${attrName}`;
-            return NodeFilter.FILTER_ACCEPT;
-          }
-        }
-      }
-
-      // We didn't find the random string in this node
-      return NodeFilter.FILTER_REJECT;
-    });
-
-    // Use the iterator to modify the real DOM
-    let nodeWithData;
-    while (nodeWithData = nodeIterator.nextNode()) {
-      // Build a querySelector for the real DOM based on the node we found in the randomized DOM
-      let addressIndices = getDOMNodeAddress(nodeWithData);
-      let selector = "html";
-      // element at index 0 is always the `<html>` element, so shift() to ignore it
-      addressIndices.shift();
-      addressIndices.forEach(index => {
-        // TextNodes will have a -1 at the end since a textNode is not considered a child
-        //  :nth-child() is 1 indexed instead of 0 indexed
-        if (index != -1) {
-          selector = `${selector} > :nth-child(${index+1})`;
-        }
+        module.initCFDebugger(rerender);
       });
+  }
 
-      const realDOMNode = document.querySelector(selector);
-      realDOMNode.dataset.cfdTooltip = true;
-      // We need to add a random suffix here so that if a div uses two different
-      //  fields, there won't be namespace conflicts in the data-attributes
-      const randKey = makeNumber(12);
-      realDOMNode.dataset[`cfdSource_${randKey}`] = key;
-      realDOMNode.dataset[`cfdUsageType_${randKey}`] = nodeWithData.cfdUsage;
-    }
-  });
-
-  // Some code to render a basic hover tooltip UI element
-  document.querySelectorAll('[data-cfd-tooltip]').forEach(el => {
-    // Parse the data stored in the data-attributes cfdSource and cfdUsageType
-    let cfdInfo = {};
-    Object.entries(el.dataset).forEach(([key, val]) => {
-      if (key.includes('cfdSource')) {
-        const [_, id] = key.split('_');
-        if (!cfdInfo[id]) { cfdInfo[id] = {}; }
-        cfdInfo[id].source = el.dataset[key];
-      } else if (key.includes('cfdUsageType')) {
-        const [_, id] = key.split('_');
-        if (!cfdInfo[id]) { cfdInfo[id] = {}; }
-        cfdInfo[id].usage = el.dataset[key];
-      }
-    });
-
-    // Create & render a new div when the element is hovered
-    const toolTipEl = document.createElement('div');
-    toolTipEl.classList.add('CFD-tooltip');
-    let innerHTML = '';
-    Object.entries(cfdInfo).forEach(([key, val]) => {
-      innerHTML = innerHTML + `<div class="CFD-section"><span class="CFD-source">Data Field: ${val.source}</span><span class="CFD-usage">Usage: ${val.usage}</span></div>`;
-    });
-    toolTipEl.innerHTML = innerHTML;
-
-    el.addEventListener('mouseenter', () => {
-      const elRect = el.getBoundingClientRect();
-      toolTipEl.style.top = `${elRect.bottom + window.scrollY}px`;
-      toolTipEl.style.left = `${elRect.left}px`;
-      document.body.appendChild(toolTipEl);
-    });
-    el.addEventListener('mouseleave', () => {
-      document.body.removeChild(toolTipEl);
-    });
-  });
+  window.enableCFDebugger();
 };
 //@ts-ignore
 if (!import.meta.env.SSR) hydrate();

--- a/entry.js
+++ b/entry.js
@@ -41,7 +41,8 @@ const hydrate = async () => {
    */
   const templateFilename = window._RSS_TEMPLATE_?.split('.')[0];
 
-  const { default: component } = (await routes.find((route) => route.name === templateFilename)?.getComponent()) || {};
+  const { default: component, render: renderComponent } = (await routes.find((route) => route.name === templateFilename)?.getComponent()) || {};
+
   ReactDOM.hydrate(
     _jsx(App, {
       page: {
@@ -54,6 +55,170 @@ const hydrate = async () => {
     }),
     document.getElementById('root'),
   );
+
+  function makeid(length) {
+    var result           = '';
+    var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    var charactersLength = characters.length;
+    for ( var i = 0; i < length; i++ ) {
+      result += characters.charAt(Math.floor(Math.random() * 
+  charactersLength));
+   }
+   return result;
+  }
+  
+  function makeNumber(length) {
+    var result           = '';
+    var characters       = '123456789';
+    var charactersLength = characters.length;
+    for ( var i = 0; i < length; i++ ) {
+      result += characters.charAt(Math.floor(Math.random() * 
+  charactersLength));
+   }
+   return Number(result);
+  }
+
+  function randomize(v) {
+    if (typeof v === 'string') return makeid(12);
+    if (typeof v === 'number') return makeNumber(12);
+    if (Array.isArray(v)) return v.map(randomize)
+    if (typeof v === 'object') return Object.keys(v).reduce((out, key) => ({...out, [key]: key === 'hours' ? v[key] : randomize(v[key])}), {})
+  }
+
+  // Returns a flattened object while preserving nested key names
+  //  using '.' as a separator ex.
+  //  {parent: {child: 'hello'}} => {parent.child: 'hello'}
+  function flattenObj(input, parentKey="") {
+    let flattened = {};
+    Object.entries(input).forEach(([key, val]) => {
+      if (typeof val === 'object') {
+        flattened = {
+          ...flattened,
+          ...flattenObj(val, `${parentKey}${key}.`),
+        }
+      } else if (typeof val === 'array') {
+         val.forEach((el, idx) => {
+           flattened = {
+             ...flattened,
+             ...flattenObj(el, `${parentKey}${key}.${idx}.`),
+           }
+         })
+      } else {
+        flattened[`${parentKey}${key}`] = val;
+      }
+    });
+    return flattened;
+  }
+
+  // Returns an array of sibling indicies from document root to the param `node`
+  //  so I can use :nth-child selectors to uniquely identify any element
+  function getDOMNodeAddress(node, address = []) {
+    if (node.nodeType === Node.DOCUMENT_NODE) {
+      return address;
+    }
+
+    // Find the index of this node among it's siblings
+    const siblingIndex = Array.from(node.parentNode.children).indexOf(node);
+    return getDOMNodeAddress(node.parentNode, [siblingIndex, ...address]);
+  }
+
+  // re-calculate the HTML string of the component with random props (no update to the visible page)
+  const fakeProps = {
+    document: {streamOutput: randomize(window._RSS_PROPS_.data.document.streamOutput)},
+    __meta: { // throws error if this doesn't exist (?)
+      manifest: { bundlerManifest: {}},
+    },
+  }
+  const randomizedComponentString = renderComponent(fakeProps);
+  const randomizedComponentDOMNode = new DOMParser().parseFromString(randomizedComponentString, 'text/html');
+  const flatProps = flattenObj(fakeProps);
+
+  // For each randomized prop, search the randomized DOM for where the random string occurs
+  Object.entries(flatProps).forEach(([key, val]) => {
+
+    // Create a filtered Node Iterator which will find locations in the DOM where the random string occurs
+    const nodeIterator = document.createNodeIterator(randomizedComponentDOMNode.body, NodeFilter.SHOW_ALL, (node) => {
+      // The string could be textContent for an element
+      if (node.nodeType === Node.TEXT_NODE && node.textContent === val) {
+        node.cfdUsage = 'textContent';
+        return NodeFilter.FILTER_ACCEPT;
+
+      // The string could be an attribute on an element
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const attrs = node.getAttributeNames();
+        for (const attrName of attrs) {
+          if (node.getAttribute(attrName) === val) {
+            node.cfdUsage = `attribute_${attrName}`;
+            return NodeFilter.FILTER_ACCEPT;
+          }
+        }
+      }
+
+      // We didn't find the random string in this node
+      return NodeFilter.FILTER_REJECT;
+    });
+
+    // Use the iterator to modify the real DOM
+    let nodeWithData;
+    while (nodeWithData = nodeIterator.nextNode()) {
+      // Build a querySelector for the real DOM based on the node we found in the randomized DOM
+      let addressIndices = getDOMNodeAddress(nodeWithData);
+      let selector = "html";
+      // element at index 0 is always the `<html>` element, so shift() to ignore it
+      addressIndices.shift();
+      addressIndices.forEach(index => {
+        // TextNodes will have a -1 at the end since a textNode is not considered a child
+        //  :nth-child() is 1 indexed instead of 0 indexed
+        if (index != -1) {
+          selector = `${selector} > :nth-child(${index+1})`;
+        }
+      });
+
+      const realDOMNode = document.querySelector(selector);
+      realDOMNode.dataset.cfdTooltip = true;
+      // We need to add a random suffix here so that if a div uses two different
+      //  fields, there won't be namespace conflicts in the data-attributes
+      const randKey = makeNumber(12);
+      realDOMNode.dataset[`cfdSource_${randKey}`] = key;
+      realDOMNode.dataset[`cfdUsageType_${randKey}`] = nodeWithData.cfdUsage;
+    }
+  });
+
+  // Some code to render a basic hover tooltip UI element
+  document.querySelectorAll('[data-cfd-tooltip]').forEach(el => {
+    // Parse the data stored in the data-attributes cfdSource and cfdUsageType
+    let cfdInfo = {};
+    Object.entries(el.dataset).forEach(([key, val]) => {
+      if (key.includes('cfdSource')) {
+        const [_, id] = key.split('_');
+        if (!cfdInfo[id]) { cfdInfo[id] = {}; }
+        cfdInfo[id].source = el.dataset[key];
+      } else if (key.includes('cfdUsageType')) {
+        const [_, id] = key.split('_');
+        if (!cfdInfo[id]) { cfdInfo[id] = {}; }
+        cfdInfo[id].usage = el.dataset[key];
+      }
+    });
+
+    // Create & render a new div when the element is hovered
+    const toolTipEl = document.createElement('div');
+    toolTipEl.classList.add('CFD-tooltip');
+    let innerHTML = '';
+    Object.entries(cfdInfo).forEach(([key, val]) => {
+      innerHTML = innerHTML + `<div class="CFD-section"><span class="CFD-source">Data Field: ${val.source}</span><span class="CFD-usage">Usage: ${val.usage}</span></div>`;
+    });
+    toolTipEl.innerHTML = innerHTML;
+
+    el.addEventListener('mouseenter', () => {
+      const elRect = el.getBoundingClientRect();
+      toolTipEl.style.top = `${elRect.bottom + window.scrollY}px`;
+      toolTipEl.style.left = `${elRect.left}px`;
+      document.body.appendChild(toolTipEl);
+    });
+    el.addEventListener('mouseleave', () => {
+      document.body.removeChild(toolTipEl);
+    });
+  });
 };
 //@ts-ignore
 if (!import.meta.env.SSR) hydrate();

--- a/src/components/clickableThing.tsx
+++ b/src/components/clickableThing.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+const ClickableThing = (props: {name: any}) => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div className="ClickableThing" onClick={() => setCount(count + 1)}>
+      Hi {props.name}, clicked {count} times
+    </div>
+  );
+};
+
+export default ClickableThing;

--- a/src/components/customFieldDebugger/usagePanel.tsx
+++ b/src/components/customFieldDebugger/usagePanel.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react';
+
+type UsagePanelProps = {
+  fields: {
+    [key: string]: string,
+  };
+  usageMap: {
+    [key: string]: Array<HTMLElement>,
+  };
+  proxyUsageList: {
+    [key: string]: boolean,
+  };
+};
+
+const UsagePanel = (props: UsagePanelProps) => {
+  const { fields } = props;
+  const [isVisible, setVisible] = useState(false);
+  const [sortedColIdx, setSortedColIdx] = useState(1);
+  const [sortedDirection, setSortedDirection] = useState('ascending');
+
+  // Clicking the "sort" button for the same `sortedColIdx` will reverse the sort
+  // Clicking the "sort" button for a different `sortedColIdx` will sort by that column instead
+  const toggleSortState = (colIdx: number) => {
+    if (colIdx === sortedColIdx) {
+      setSortedDirection(sortedDirection === 'ascending' ? 'descending' : 'ascending');
+    } else {
+      setSortedDirection('ascending');
+      setSortedColIdx(colIdx);
+    }
+  }
+
+  // aggregate data from field data + `usageMap` + `proxyUsageList` to `UsagePanelFieldProps`
+  const getFieldProps = (field: [string, string]): UsagePanelFieldProps => {
+    const [fieldKey, fieldVal] = field;
+    let shortKey = fieldKey;
+    const prefix = 'document.streamOutput.';
+    if (shortKey.startsWith(prefix)) {
+      shortKey = shortKey.slice(prefix.length);
+    }
+  
+    let shortVal = fieldVal;
+    const maxStrLen = 40;
+    if (typeof shortVal === 'string' && shortVal.length > maxStrLen) {
+      shortVal = `${shortVal.slice(0, maxStrLen)}...`;
+    }
+  
+    const fieldIsUsed = !!(props.usageMap[fieldKey] || props.proxyUsageList[fieldKey]);
+    let fieldStatus = 'notUsed';
+    if (props.usageMap[fieldKey]) { fieldStatus = 'used'; }
+    else if (props.proxyUsageList[fieldKey]) { fieldStatus = 'internal'; }
+
+    const usageEls = props.usageMap[fieldKey];
+
+    return {
+      fieldKey: shortKey,
+      fieldVal: shortVal.toString(),
+      fieldIsUsed,
+      fieldStatus,
+      usedEls: usageEls,
+    };
+  }
+
+  const getSortFnFromState = () => {
+    const colIdxToPropKey: {[key: number]: string} = {
+      0: 'fieldStatus',
+      1: 'fieldKey',
+    };
+
+    const fieldStatusSortIndices: {[key: string]: string} = {
+      'used': '0',
+      'internal': '1',
+      'notUsed': '2',
+    };
+
+    return (a: UsagePanelFieldProps, b: UsagePanelFieldProps) => {
+      let a_value = a[colIdxToPropKey[sortedColIdx] as keyof UsagePanelFieldProps];
+      let b_value = b[colIdxToPropKey[sortedColIdx] as keyof UsagePanelFieldProps];
+
+      if (!(a_value && b_value)) { return 0; }
+
+      // Field statuses should not be sorted alphabetically, instead use the pre-defined order above
+      if (colIdxToPropKey[sortedColIdx] === 'fieldStatus') {
+        a_value = fieldStatusSortIndices[a_value as string];
+        b_value = fieldStatusSortIndices[b_value as string];
+      }
+
+      if (sortedDirection === 'ascending') {
+        return a_value > b_value ? 1 : -1;
+      } else {
+        return a_value < b_value ? 1 : -1;
+      }
+    }
+  }
+
+  return (
+    <div className={`CFD-usagePanel CFDUsagePanel${isVisible ? ' is-visible' : ''}`}>
+      <div className="CFDUsagePanel-headingRow">
+        <div className="CFDUsagePanel-fieldStatus CFDUsagePanel-heading">
+          Status
+          <button className="CFDUsagePanel-headingSortButton" onClick={() => toggleSortState(0)}>
+            <span className={`CFDUsagePanel-headingSortIcon${sortedColIdx === 0 ? ` is-sorted is-${sortedDirection}` : ''}`}></span>
+          </button>
+        </div>
+        <div className="CFDUsagePanel-fieldSummary CFDUsagePanel-heading">
+          Field Data
+          <button className="CFDUsagePanel-headingSortButton" onClick={() => toggleSortState(1)}>
+            <span className={`CFDUsagePanel-headingSortIcon${sortedColIdx === 1 ? ` is-sorted is-${sortedDirection}` : ''}`}></span>
+          </button>
+        </div>
+      </div>
+      <div className="CFDUsagePanel-scrollable">
+        {Object.entries(fields).map(field => getFieldProps(field)).sort(getSortFnFromState()).map((fieldProps, idx) => 
+          <UsagePanelField key={idx} {...fieldProps} />
+        )}
+      </div>
+      <button className="CFD-usageBtn" onClick={() => setVisible(!isVisible)}></button>
+    </div>
+  );
+};
+
+type UsagePanelFieldProps = {
+  fieldKey: string,
+  fieldVal: string,
+  fieldIsUsed: boolean,
+  fieldStatus: string,
+  usedEls?: Array<HTMLElement>,
+}
+
+const UsagePanelField = (props: UsagePanelFieldProps) => {
+  const { fieldKey, fieldVal, fieldIsUsed, fieldStatus, usedEls } = props;
+
+  const statusToDisplayedStatus: {[key:string]: string} = {
+    'notUsed': 'Not Used',
+    'used': 'On Page',
+    'internal': 'Internal Logic'
+  };
+
+  // Clicking a field should reveal its usage location on the page
+  const showUsageLocation = () => {
+    if (usedEls && usedEls.length > 0) {
+      const el = usedEls[0];
+      document.querySelectorAll('.CFD-isSelected').forEach(el => el.classList.remove('CFD-isSelected'));
+      el.classList.add('CFD-isSelected');
+      window.scrollTo({top: el.getBoundingClientRect().top, behavior: 'smooth'});
+    }
+  }
+
+  return (
+    <div className={`CFDUsagePanel-field${fieldIsUsed ? ' CFDUsagePanel-field--used' : ' CFDUsagePanel-field--notUsed'}`} onClick={() => showUsageLocation()}>
+      <span className={`CFDUsagePanel-fieldStatusIndicator CFDUsagePanel-fieldStatusIndicator--${fieldStatus}`}></span>
+      <span className="CFDUsagePanel-fieldStatus">{statusToDisplayedStatus[fieldStatus]}</span>
+      <span className="CFDUsagePanel-fieldSummary">
+        <span className="CFDUsagePanel-fieldSummaryKey">{fieldKey}</span>
+        <span className="CFDUsagePanel-fieldSummaryVal">{fieldVal}</span>
+      </span>
+    </div>
+  )
+}
+
+export default UsagePanel;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -2,7 +2,7 @@ import Cta from '../components/cta';
 
 type Link = {
   label: string;
-  url: string;
+  uRL: string;
 };
 
 type Header = {
@@ -12,25 +12,23 @@ type Header = {
 
 const Header = (props: Header) => {
   const { links, logo } = props;
-  const linkDoms = links.map((link) => (
-    <div>
-      <a href={link.url} target="_blank">
-        {link.label}
-      </a>
-    </div>
-  ));
   return (
     <>
       <div className="centered-container">
         <nav className="py-6 flex items-center justify-between">
           <img src={logo} width="50" height="50"></img>
           <div className="text-2xl font-semibold">Yext's Fashion Warehouse</div>
-          {/* <div>{JSON.stringify(links)}</div> */}
-          {/* <div className="flex gap-x-10 text-lg font-semibold">{linkDoms}</div> */}
-          <div className="space-x-5">
+          <div className="flex gap-x-10 text-lg font-semibold">
+            {links.map((link, idx) => 
+              <a key={idx} href={link.uRL} target="_blank">
+                {link.label}
+              </a>
+            )}
+          </div>
+          {/* <div className="space-x-5">
             <Cta buttonText="Order Pickup" url="#" style="primary-cta"></Cta>
             <Cta buttonText="Order Delivery" url="#" style="secondary-cta"></Cta>
-          </div>
+          </div> */}
         </nav>
       </div>
     </>

--- a/src/components/tabbableThing.tsx
+++ b/src/components/tabbableThing.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+const TabbableThing = (props: {tab1: string, tab2: string}) => {
+  const [tabIndex, setTabIndex] = useState(0);
+
+  return (
+    <div className="TabbableThing">
+      <div className="TabbableThing-buttons">
+        <button onClick={() => setTabIndex(0)}>Tab 1</button>
+        <button onClick={() => setTabIndex(1)}>Tab 2</button>
+      </div>
+      <div className="TabbableThing-tabs">
+        {tabIndex == 0 && 
+          <div className="TabbableThing-tab">
+            Tab 1 content -- {props.tab1}
+          </div>
+        }
+        {tabIndex == 1 && 
+          <div className="TabbableThing-tab">
+            Tab 2 content -- {props.tab2}
+          </div>
+        }
+      </div>
+    </div>
+  )
+};
+
+export default TabbableThing;

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,10 @@
     @apply bg-sky-700 hover:bg-sky-800;
 }
 
+[data-cfd-tooltip] {
+    outline: 2px solid red;
+}
+
 .CFD-tooltip {
     position: absolute;
     background-color: rgba(0, 0, 0, 0.7);
@@ -35,4 +39,98 @@
 
 .CFD-usage {
     font-size: 10px;
+}
+
+.CFDUsagePanel {
+    position: fixed;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%) translateX(100%);
+    background-color: rgb(22, 22, 22);
+    padding: 16px 0;
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 8px;
+    font-size: 14px;
+    color: #fff;
+    transition: transform 0.5s ease;
+}
+
+.CFDUsagePanel.is-visible {
+    transform: translateY(-50%) translateX(0);
+}
+
+.CFDUsagePanel.is-visible .CFD-usageBtn::after {
+    border-right: 8px solid transparent;
+    border-left: 8px solid #fff;
+    transform: translate(-25%, -50%);
+}
+
+.CFDUsagePanel-scrollable {
+    height: 600px;
+    overflow-y: auto;
+}
+
+.CFD-usageBtn {
+    position: absolute;
+    left: -30px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 30px;
+    height: 60px;
+    background-color: rgb(22, 22, 22);
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+}
+
+.CFD-usageBtn::after {
+    content: '';
+    border: 8px solid transparent;
+    border-right: 8px solid #fff;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-75%, -50%);
+}
+
+.CFDUsagePanel-field {
+    padding: 0 16px;
+}
+
+.CFDUsagePanel-field:nth-child(2n) {
+    background-color: rgb(44, 44, 44);
+}
+
+.CFDUsagePanel-fieldSummary {
+    display: inline-flex;
+    flex-direction: column;
+}
+
+.CFDUsagePanel-fieldSummaryKey {
+    font-weight: 600;
+}
+
+.CFDUsagePanel-fieldSummaryVal {
+    font-size: 12px;
+    padding-left: 12px;
+}
+
+.CFDUsagePanel-fieldStatus {
+    width: 70px;
+    display: inline-block;
+}
+
+.CFDUsagePanel-field--notUsed {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.CFDUsagePanel-field--notUsed .CFDUsagePanel-fieldStatus {
+    font-style: italic;
+}
+
+.CFDUsagePanel-field--used:hover {
+    cursor: pointer;
+}
+
+.CFD-isSelected {
+    background-color: palegreen;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -92,6 +92,75 @@
     transform: translate(-75%, -50%);
 }
 
+.CFDUsagePanel-headingRow {
+    padding: 4px 16px;
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid #fff;
+}
+
+.CFDUsagePanel-headingSortButton {
+    display: flex;
+    position: relative;
+    left: 4px;
+    padding: 8px;
+}
+
+.CFDUsagePanel-headingSortIcon {
+    position: relative;
+    height: 8px;
+    width: 8px;
+    border-radius: 50%;
+    background-color: #6b6b6b;
+    border: 2px solid #000;
+}
+
+.CFDUsagePanel-headingSortIcon::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    transform: translateX(-50%);
+    border-bottom: 8px solid #6b6b6b;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    z-index: -1;
+}
+
+.CFDUsagePanel-headingSortIcon::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    transform: translateX(-50%);
+    border-top: 8px solid #6b6b6b;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    z-index: -1;
+}
+
+.CFDUsagePanel-headingSortIcon.is-sorted {
+    background-color: #fff;
+}
+
+.CFDUsagePanel-headingSortIcon.is-ascending::before {
+    border-bottom-color: #fff;
+}
+
+.CFDUsagePanel-headingSortIcon.is-descending::after {
+    border-top-color: #fff;
+}
+
+.CFDUsagePanel-headingRow .CFDUsagePanel-heading {
+    font-size: 16px;
+    font-weight: 700;
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.CFDUsagePanel-heading.CFDUsagePanel-fieldStatus {
+    margin-right: 14px;
+}
+
 .CFDUsagePanel-field {
     padding: 4px 16px;
     display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -93,7 +93,9 @@
 }
 
 .CFDUsagePanel-field {
-    padding: 0 16px;
+    padding: 4px 16px;
+    display: flex;
+    align-items: center;
 }
 
 .CFDUsagePanel-field:nth-child(2n) {
@@ -114,8 +116,28 @@
     padding-left: 12px;
 }
 
+.CFDUsagePanel-fieldStatusIndicator {
+    height: 10px;
+    width: 10px;
+    border-radius: 50%;
+    margin-right: 4px;
+}
+
+.CFDUsagePanel-fieldStatusIndicator--used {
+    background-color: palegreen;
+}
+
+.CFDUsagePanel-fieldStatusIndicator--internal {
+    background-color: gold;
+}
+
+.CFDUsagePanel-fieldStatusIndicator--notUsed {
+    background-color: #8b8b8b;
+}
+
 .CFDUsagePanel-fieldStatus {
-    width: 70px;
+    width: 80px;
+    font-size: 11px;
     display: inline-block;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -17,3 +17,22 @@
 .secondary-cta{
     @apply bg-sky-700 hover:bg-sky-800;
 }
+
+.CFD-tooltip {
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.7);
+    border-radius: 4px;
+    color: #fff;
+    font-size: 12px;
+    padding: 4px 8px;
+}
+
+.CFD-section {
+    display: flex;
+    flex-direction: column;
+    padding: 4px 0;
+}
+
+.CFD-usage {
+    font-size: 10px;
+}

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -75,6 +75,7 @@ const Index = ({ data }: { data: any }) => {
           <Cta buttonText="Get Directions" url="http://google.com" style="primary-cta" />
         </div>
       </Banner>
+      <a className="link1" href={_site.c_header[0].uRL}>{_site.c_header[0].label}</a>
       <div className="centered-container">
         <div className="section">
           <div className="grid grid-cols-3 gap-x-10 gap-y-10">

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -58,7 +58,7 @@ export const getPath = (data: any) => {
 const Index = ({ data }: { data: any }) => {
   const { document } = data;
   const { streamOutput } = document;
-  const { name, address, openTime, hours, mainPhone, _site, geocodedCoordinate, services, photoGallery } = streamOutput;
+  const { name, address, openTime, hours, mainPhone, _site, geocodedCoordinate, services, photoGallery, locale, id } = streamOutput;
   const { t, i18n } = useTranslation();
 
   return (
@@ -71,9 +71,11 @@ const Index = ({ data }: { data: any }) => {
       </div>
       <Banner name={name} address={address} openTime={openTime}>
         <div className="bg-white h-40 w-1/5 flex items-center justify-center text-center flex-col space-y-4 rounded-lg">
-          <div className="text-black text-base">Visit Us Today!</div>
-          <div className="text-black text-base"><Trans>hello world</Trans></div>
-          <div className="text-black text-base">{t('hello world')}</div>
+          <div className="text-black text-base">
+            {locale === 'en' ? 'Visit Us Today!' : 'Locale is not EN'}
+          </div>
+          {/* <div className="text-black text-base"><Trans>hello world</Trans></div>
+          <div className="text-black text-base">{t('hello world')}</div> */}
           <Cta buttonText="Get Directions" url="http://google.com" style="primary-cta" />
         </div>
       </Banner>

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -12,6 +12,8 @@ import { renderToString } from 'react-dom/server';
 import '../index.css';
 
 import { Trans, useTranslation } from 'react-i18next';
+import ClickableThing from '../components/clickableThing';
+import TabbableThing from '../components/tabbableThing';
 
 export const config = {
   name: 'index',
@@ -76,6 +78,8 @@ const Index = ({ data }: { data: any }) => {
         </div>
       </Banner>
       <a className="link1" href={_site.c_header[0].uRL}>{_site.c_header[0].label}</a>
+      <ClickableThing name={name} />
+      <TabbableThing tab1={name} tab2={address.line1} />
       <div className="centered-container">
         <div className="section">
           <div className="grid grid-cols-3 gap-x-10 gap-y-10">


### PR DESCRIPTION
- Uses the "Generate random strings for field data & search for where they are rendered" strategy
- Handles fields that are directly rendered on the page, as well as strings which are contained in HTML elements' attributes (like `href=` etc).
- Avoids adding any new HTML elements to the page (no wrapping elements in `<spans>`) because I think that poses a risk of breaking the layout of some pages?

Works by calling the template's exported `render()` function with a randomized set of fake props, and then searching that virtual DOM for where each field's randomized data occurs. If a match is found, a unique address for that fake DOM element is calculated using :nth-child selectors & finds the matching element in the real DOM. Then, add data-attributes to those HTML elements in the real DOM. Also, a developer could manually tag elements by adding the attributes by hand if they are not picked up by the automatic detection.